### PR TITLE
Feature/external activation

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,28 @@
+# == Class ssm::config
+#
+# This class is called from ssm::init to config the SSM Agent.
+#
+# == Parameters
+#
+# [*proxy_host*]
+#   proxy_host to be used by ssm agent, <HOST-ADDR>:<PORT>
+#
+class ssm::config(
+  $proxy_host = $ssm::params::proxy_host,
+) inherits ssm::params { # lint:ignore:class_inherits_from_params_class
+
+  if $proxy_host {
+    file { '/lib/systemd/system/amazon-ssm-agent.service':
+      ensure  => present,
+      content => template('ssm/amazon-ssm-agent.systemd'),
+      notify  => Service[$service_name],
+    } ~> exec { 'ssm-systemd-reload':
+      command     => 'systemctl daemon-reload',
+      path        => '/bin:/usr/bin:/usr/local/bin:/usr/sbin',
+      logoutput   => on_failure,
+      notify      => Service[$service_name],
+      refreshonly => true,
+    }
+  }
+
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,21 +12,33 @@
 #   automatically determined based on the platform.
 #
 class ssm::config(
-  $proxy_host   = $ssm::params::proxy_host,
-  $service_name = $ssm::params::manage_service,
+  $proxy_host       = $ssm::params::proxy_host,
+  $service_name     = $ssm::params::manage_service,
+  $service_provider = $ssm::params::service_provider,
 ) inherits ssm::params { # lint:ignore:class_inherits_from_params_class
 
   if $proxy_host {
-    file { '/lib/systemd/system/amazon-ssm-agent.service':
-      ensure  => present,
-      content => template('ssm/amazon-ssm-agent.systemd'),
-      notify  => Service[$service_name],
-    } ~> exec { 'ssm-systemd-reload':
-      command     => 'systemctl daemon-reload',
-      path        => '/bin:/usr/bin:/usr/local/bin:/usr/sbin',
-      logoutput   => on_failure,
-      notify      => Service[$service_name],
-      refreshonly => true,
+    case $service_provider {
+      'systemd': {
+        file { '/lib/systemd/system/amazon-ssm-agent.service':
+          ensure  => present,
+          content => template('ssm/amazon-ssm-agent.systemd'),
+        } ~> exec { 'ssm-systemd-reload':
+          command     => 'systemctl daemon-reload',
+          path        => '/bin:/usr/bin:/usr/local/bin:/usr/sbin',
+          logoutput   => on_failure,
+          notify      => Service[$service_name],
+          refreshonly => true,
+        }
+      }
+      'init', 'upstart': {
+        file { '/etc/init/amazon-ssm-agent.override':
+          ensure  => present,
+          content => template('ssm/amazon-ssm-agent.override'),
+          notify  => Service[$service_name],
+        }
+      }
+      default: {}
     }
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,8 +7,13 @@
 # [*proxy_host*]
 #   proxy_host to be used by ssm agent, <HOST-ADDR>:<PORT>
 #
+# [*service_name*]
+#   String indicating the name of the SSM service. The correct value is
+#   automatically determined based on the platform.
+#
 class ssm::config(
-  $proxy_host = $ssm::params::proxy_host,
+  $proxy_host   = $ssm::params::proxy_host,
+  $service_name = $ssm::params::manage_service,
 ) inherits ssm::params { # lint:ignore:class_inherits_from_params_class
 
   if $proxy_host {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,7 +13,7 @@
 #
 class ssm::config(
   $proxy_host       = $ssm::params::proxy_host,
-  $service_name     = $ssm::params::manage_service,
+  $service_name     = $ssm::params::service_name,
   $service_provider = $ssm::params::service_provider,
 ) inherits ssm::params { # lint:ignore:class_inherits_from_params_class
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,16 +65,18 @@
 # lint:ignore:80chars
 #
 class ssm (
-  $custom_path    = $ssm::params::custom_path,
-  $custom_url     = $ssm::params::custom_url,
-  $flavor         = $ssm::params::flavor,
-  $manage_service = $ssm::params::manage_service,
-  $package        = $ssm::params::package,
-  $provider       = $ssm::params::provider,
-  $region         = $ssm::params::region,
-  $service_enable = $ssm::params::service_enable,
-  $service_ensure = $ssm::params::service_ensure,
-  $service_name   = $ssm::params::service_name,
+  $custom_path     = $ssm::params::custom_path,
+  $custom_url      = $ssm::params::custom_url,
+  $flavor          = $ssm::params::flavor,
+  $manage_service  = $ssm::params::manage_service,
+  $package         = $ssm::params::package,
+  $provider        = $ssm::params::provider,
+  $region          = $ssm::params::region,
+  $activation_code = $ssm::params::activation_code,
+  $activation_id   = $ssm::params::activation_id,
+  $service_enable  = $ssm::params::service_enable,
+  $service_ensure  = $ssm::params::service_ensure,
+  $service_name    = $ssm::params::service_name,
 ) inherits ssm::params { # lint:ignore:class_inherits_from_params_class
 
   if $custom_url {
@@ -111,6 +113,12 @@ class ssm (
     url      => $url,
   }
 
+  class { 'ssm::register':
+    activation_code => $activation_code,
+    activation_id   => $activation_id,
+    region          => $region,
+  }
+
   class { 'ssm::service':
     manage_service => $manage_service,
     service_enable => $service_enable,
@@ -118,6 +126,6 @@ class ssm (
     service_name   => $service_name,
   }
 
-  anchor { 'ssm::begin': } -> Class['ssm::install'] -> Class['ssm::service'] -> anchor { 'ssm::end': }
+  anchor { 'ssm::begin': } -> Class['ssm::install'] -> Class['ssm::register'] -> Class['ssm::service'] -> anchor { 'ssm::end': }
   # lint:endignore
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,7 @@ class ssm (
   $region          = $ssm::params::region,
   $activation_code = $ssm::params::activation_code,
   $activation_id   = $ssm::params::activation_id,
+  $proxy_host      = $ssm::params::proxy_host,
   $service_enable  = $ssm::params::service_enable,
   $service_ensure  = $ssm::params::service_ensure,
   $service_name    = $ssm::params::service_name,
@@ -113,6 +114,10 @@ class ssm (
     url      => $url,
   }
 
+  class { 'ssm::config':
+    proxy_host => $proxy_host,
+  }
+
   class { 'ssm::register':
     activation_code => $activation_code,
     activation_id   => $activation_id,
@@ -126,6 +131,6 @@ class ssm (
     service_name   => $service_name,
   }
 
-  anchor { 'ssm::begin': } -> Class['ssm::install'] -> Class['ssm::register'] -> Class['ssm::service'] -> anchor { 'ssm::end': }
+  anchor { 'ssm::begin': } -> Class['ssm::install'] ->  Class['ssm::config'] -> Class['ssm::register'] -> Class['ssm::service'] -> anchor { 'ssm::end': }
   # lint:endignore
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,12 +19,29 @@ class ssm::params {
       $package = 'rpm'
       $provider = 'rpm'
       $flavor = 'linux'
+      $service_provider = 'systemd'
     }
-    'Debian', 'Ubuntu': {
+    'Debian': {
       $service_name = 'amazon-ssm-agent'
       $package = 'deb'
       $provider = 'dpkg'
       $flavor = 'debian'
+      if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
+        $service_provider = 'systemd'
+      } else {
+        $service_provider = 'init'
+      }
+    }
+    'Ubuntu': {
+      $service_name = 'amazon-ssm-agent'
+      $package = 'deb'
+      $provider = 'dpkg'
+      $flavor = 'debian'
+      if versioncmp($::operatingsystemmajrelease, '16') >= 0 {
+        $service_provider = 'systemd'
+      } else {
+        $service_provider = 'upstart'
+      }
     }
     default: {
       fail("Module not supported on ${::operatingsystem}.")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class ssm::params {
   $region          = undef
   $activation_code = false
   $activation_id   = false
+  $proxy_host      = false
   $service_enable  = true
   $service_ensure  = 'running'
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,12 +3,14 @@
 # This class is called from ssm::init to set variable defaults.
 #
 class ssm::params {
-  $custom_path    = false
-  $custom_url     = false
-  $manage_service = true
-  $region         = undef
-  $service_enable = true
-  $service_ensure = 'running'
+  $custom_path     = false
+  $custom_url      = false
+  $manage_service  = true
+  $region          = undef
+  $activation_code = false
+  $activation_id   = false
+  $service_enable  = true
+  $service_ensure  = 'running'
 
   case $::operatingsystem {
     'Amazon', 'CentOS', 'OracleLinux', 'RedHat', 'Scientific': {

--- a/manifests/register.pp
+++ b/manifests/register.pp
@@ -1,0 +1,33 @@
+# == Class ssm::register
+#
+# This class is called from ssm::init to register the SSM Agent.
+#
+# == Parameters
+#
+# [*activation_code*]
+#   Activation Code provided by System manager upon creation of an activation. Required.
+#
+# [*acivation_id*]
+#   Activation ID provided by System manager upon creation of an activation. Required.
+#
+# [*region*]
+#   String indicating the AWS region in which the instance is running. Required.
+#   Defaults to `undef`.
+#
+class ssm::register(
+  $activation_code = $ssm::params::acivation_code,
+  $acivation_id    = $ssm::params::acivation_id,
+  $region          = $ssm::params::region,
+) inherits ssm::params { # lint:ignore:class_inherits_from_params_class
+
+  if ($activation_code) and ($acivation_id) {
+    exec { 'register-ssm-agent':
+      command   => "amazon-ssm-agent -register -code ${activation_code} -id ${acivation_id} -region ${region}",
+      path      => '/bin:/usr/bin:/usr/local/bin:/usr/sbin',
+      logoutput => on_failure,
+      timeout   => 600,
+      creates   => '/var/lib/amazon/ssm/Vault/Store/RegistrationKey',
+    }
+  }
+
+}

--- a/manifests/register.pp
+++ b/manifests/register.pp
@@ -14,10 +14,15 @@
 #   String indicating the AWS region in which the instance is running. Required.
 #   Defaults to `undef`.
 #
+# [*service_name*]
+#   String indicating the name of the SSM service. The correct value is
+#   automatically determined based on the platform.
+#
 class ssm::register(
-  $activation_code = $ssm::params::acivation_code,
+  $activation_code  = $ssm::params::acivation_code,
   $activation_id    = $ssm::params::activation_id,
-  $region          = $ssm::params::region,
+  $service_name     = $ssm::params::service_name,
+  $region           = $ssm::params::region,
 ) inherits ssm::params { # lint:ignore:class_inherits_from_params_class
 
   if ($activation_code) and ($activation_id) {
@@ -26,6 +31,7 @@ class ssm::register(
       path      => '/bin:/usr/bin:/usr/local/bin:/usr/sbin',
       logoutput => on_failure,
       timeout   => 600,
+      notify    => Service[$service_name],
       creates   => '/var/lib/amazon/ssm/Vault/Store/RegistrationKey',
     }
   }

--- a/manifests/register.pp
+++ b/manifests/register.pp
@@ -18,21 +18,31 @@
 #   String indicating the name of the SSM service. The correct value is
 #   automatically determined based on the platform.
 #
+# [*proxy_host*]
+#   proxy_host to be used by ssm agent, <HOST-ADDR>:<PORT>
+#
 class ssm::register(
   $activation_code  = $ssm::params::acivation_code,
   $activation_id    = $ssm::params::activation_id,
   $service_name     = $ssm::params::service_name,
   $region           = $ssm::params::region,
+  $proxy_host       = $ssm::params::proxy_host,
 ) inherits ssm::params { # lint:ignore:class_inherits_from_params_class
+
+  $proxy_args = $proxy_host ? {
+    false    => undef,
+    default  => [ "http_proxy=http://${proxy_host}", "https_proxy=https://${proxy_host}"],
+  }
 
   if ($activation_code) and ($activation_id) {
     exec { 'register-ssm-agent':
-      command   => "amazon-ssm-agent -register -code ${activation_code} -id ${activation_id} -region ${region}",
-      path      => '/bin:/usr/bin:/usr/local/bin:/usr/sbin',
-      logoutput => on_failure,
-      timeout   => 600,
-      notify    => Service[$service_name],
-      creates   => '/var/lib/amazon/ssm/Vault/Store/RegistrationKey',
+      command     => "amazon-ssm-agent -register -code ${activation_code} -id ${activation_id} -region ${region}",
+      path        => '/bin:/usr/bin:/usr/local/bin:/usr/sbin',
+      environment => $proxy_args,
+      logoutput   => on_failure,
+      timeout     => 600,
+      notify      => Service[$service_name],
+      creates     => '/var/lib/amazon/ssm/Vault/Store/RegistrationKey',
     }
   }
 

--- a/manifests/register.pp
+++ b/manifests/register.pp
@@ -7,7 +7,7 @@
 # [*activation_code*]
 #   Activation Code provided by System manager upon creation of an activation. Required.
 #
-# [*acivation_id*]
+# [*activation_id*]
 #   Activation ID provided by System manager upon creation of an activation. Required.
 #
 # [*region*]
@@ -16,13 +16,13 @@
 #
 class ssm::register(
   $activation_code = $ssm::params::acivation_code,
-  $acivation_id    = $ssm::params::acivation_id,
+  $activation_id    = $ssm::params::activation_id,
   $region          = $ssm::params::region,
 ) inherits ssm::params { # lint:ignore:class_inherits_from_params_class
 
-  if ($activation_code) and ($acivation_id) {
+  if ($activation_code) and ($activation_id) {
     exec { 'register-ssm-agent':
-      command   => "amazon-ssm-agent -register -code ${activation_code} -id ${acivation_id} -region ${region}",
+      command   => "amazon-ssm-agent -register -code ${activation_code} -id ${activation_id} -region ${region}",
       path      => '/bin:/usr/bin:/usr/local/bin:/usr/sbin',
       logoutput => on_failure,
       timeout   => 600,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -55,15 +55,15 @@ class ssm::service(
       }
       'Amazon': {
         service { $service_name:
-          ensure    => $service_ensure,
+          ensure     => $service_ensure,
           hasstatus  => true,
           hasrestart => true,
           restart    => "/sbin/restart ${service_name}",
           start      => "/sbin/start ${service_name}",
           status     => "/sbin/status ${service_name}",
           stop       => "/sbin/stop ${service_name}",
-          subscribe => Package['amazon-ssm-agent'],
-          require   => Class['ssm::install'],
+          subscribe  => Package['amazon-ssm-agent'],
+          require    => Class['ssm::install'],
         }
       }
       default: {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -21,10 +21,11 @@
 #   automatically determined based on the platform.
 #
 class ssm::service(
-  $manage_service = $ssm::params::manage_service,
-  $service_enable = $ssm::params::service_enable,
-  $service_ensure = $ssm::params::service_ensure,
-  $service_name   = $ssm::params::manage_service,
+  $manage_service   = $ssm::params::manage_service,
+  $service_enable   = $ssm::params::service_enable,
+  $service_ensure   = $ssm::params::service_ensure,
+  $service_name     = $ssm::params::manage_service,
+  $service_provider = $ssm::params::service_provider,
 ) inherits ssm::params { # lint:ignore:class_inherits_from_params_class
 
   if $manage_service {
@@ -32,6 +33,7 @@ class ssm::service(
       'Debian': {
         service { $service_name:
           ensure    => $service_ensure,
+          provider  => $service_provider,
           enable    => $service_enable,
           subscribe => Package['amazon-ssm-agent'],
           require   => Class['ssm::install'],
@@ -40,6 +42,7 @@ class ssm::service(
       'Ubuntu': {
         service { $service_name:
           ensure    => $service_ensure,
+          provider  => $service_provider,
           enable    => $service_enable,
           subscribe => Package['amazon-ssm-agent'],
           require   => Class['ssm::install'],
@@ -48,6 +51,7 @@ class ssm::service(
       'CentOS': {
         service { $service_name:
           ensure    => $service_ensure,
+          provider  => $service_provider,
           enable    => $service_enable,
           subscribe => Package['amazon-ssm-agent'],
           require   => Class['ssm::install'],
@@ -56,6 +60,7 @@ class ssm::service(
       'Amazon': {
         service { $service_name:
           ensure     => $service_ensure,
+          provider   => $service_provider,
           hasstatus  => true,
           hasrestart => true,
           restart    => "/sbin/restart ${service_name}",

--- a/templates/amazon-ssm-agent.override
+++ b/templates/amazon-ssm-agent.override
@@ -1,0 +1,3 @@
+env http_proxy=http://<%= @proxy_host %>
+env https_proxy=https://<%= @proxy_host %>
+env no_proxy=169.254.169.254

--- a/templates/amazon-ssm-agent.systemd
+++ b/templates/amazon-ssm-agent.systemd
@@ -1,0 +1,17 @@
+[Unit]
+Description=amazon-ssm-agent
+After=network-online.target
+
+[Service]
+Environment="http_proxy=http://<%= @proxy_host %>"
+Environment="https_proxy=https://<%= @proxy_host %>"
+Environment="no_proxy=169.254.169.254"
+Type=simple
+WorkingDirectory=/usr/bin/
+ExecStart=/usr/bin/amazon-ssm-agent
+KillMode=process
+Restart=on-failure
+RestartSec=15min
+
+[Install]
+WantedBy=network-online.target


### PR DESCRIPTION
* Add the ability to preform SSM agent registration as described in [This Documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-install-managed-linux.html) Required for initialising non EC2 System manager instances
* Add the ability to config ssm agent to use a http proxy as described in [This Documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-proxy-with-ssm-agent.html).